### PR TITLE
package.json: move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   "files": [
     "lib"
   ],
-  "dependencies": {
-    "jsbarcode": "~3.4.0",
+  "peerDependencies": {
     "react": "^15.0.0"
+  },
+  "dependencies": {
+    "jsbarcode": "~3.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
Move react to peerDependencies to mitigate Refs Must Have Owner warning, see https://facebook.github.io/react/warnings/refs-must-have-owner.html

Situation:
When a webpack project have locked react version i.e. 15.3.2, npm will install `react@15.4.0` inside `react-barcode`. These two copies of `react` will trigger *Refs Must Have Owner* warning.

Moving `react` to peerDependencies will solve it.

Some famous react library also move `react` to peerDependencies. i.e. material-ui, react-datagrid.