### PR TITLE
Update react peer depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^16.0.0"
   },
   "dependencies": {
     "jsbarcode": "~3.4.0"


### PR DESCRIPTION
This PR updates the peer depedency for React to `^16.0.0`.

This stops `yarn` from showing warnings about wrong peer dependencies and stops `yarn check` from failing on the same warning. Since #9 Already included the necessary fixes to support React 16 it seems that there is nothing preventing the peer dependency from being updated.

This fixes #12 