### PR TITLE
add support for img element

### DIFF
--- a/src/react-barcode.js
+++ b/src/react-barcode.js
@@ -89,6 +89,10 @@ var Barcode = createClass({
       return (
         <canvas ref="renderElement" />
       );
+    } else if (this.props.renderer === 'img') {
+      return (
+        <img ref="renderElement" />
+      );
     }
   },
 });


### PR DESCRIPTION
I've added a small snippet of code to enable the barcode to rendered as an `<img>` element (alongside the existing `<svg>` and `<canvas>` elements). Full jsbarcode documentation [here](https://www.npmjs.com/package/jsbarcode).