### PR TITLE
Fix bug check wrong version React 16.12.0

### DIFF
--- a/src/react-barcode.js
+++ b/src/react-barcode.js
@@ -8,7 +8,7 @@ var getDOMNode;
 // Super naive semver detection but it's good enough. We support 0.12, 0.13
 // which both have getDOMNode on the ref. 0.14 and 15 make the DOM node the ref.
 var version = React.version.split(/[.-]/);
-if (version[0] === '0' && version[1] === '13' || version[1] === '12') {
+if (version[0] === '0' && (version[1] === '13' || version[1] === '12')) {
   getDOMNode = (ref) => ref.getDOMNode();
 } else {
   getDOMNode = (ref) => ref;


### PR DESCRIPTION
This condition cause crash my app.
react-barcode.js:18 Uncaught TypeError: ref.getDOMNode is not a function