### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "homepage": "http://github.com/kciter/react-barcode",
   "main": "lib/react-barcode.js",
+  "types": "src/react-barcode.d.ts",
   "scripts": {
     "lint": "eslint src/ samples/demo.js",
     "prepublish": "make clean && make all",


### PR DESCRIPTION
Currently, when using this library from npm, typescript cannot get the types declartion in this repo because the `types` field is not set.
This fixes this by adding the the required field.