### PR TITLE
chore: bump react support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0 || 18.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "jsbarcode": "^3.8.0",


### PR DESCRIPTION
Hi, thanks for the great library 

I just wanted to add the support for react `^18` instead of sticking to `18.0.0` 
it closes this issue
- #69 