### PR TITLE
fix types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "homepage": "http://github.com/kciter/react-barcode",
   "main": "lib/react-barcode.js",
-  "types": "src/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "lint": "eslint src/ samples/demo.js",
     "prepublish": "make clean && make all",


### PR DESCRIPTION
This fixed missing types errors for me when using this library.  The issue is that types end up in the lib folder when publishing but are referenced by package.json as in the src folder.