### PR TITLE
Add missing types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 export interface Options {
   width?: number;
   height?: number;
+  renderer?: "canvas" | "img" | "svg";
   format?:
     | "CODE39"
     | "CODE128"
@@ -30,5 +31,7 @@ export interface BarcodeProps extends Options {
   value: string;
 }
 
-export default class Barcode extends React.Component<BarcodeProps> {}
+export default class Barcode extends React.Component<BarcodeProps> {
+  renderElementRef: React.RefObject<HTMLCanvasElement | SVGElement | HTMLImageElement>;
+}
 


### PR DESCRIPTION
This component supports a prop named `renderer`, which allows to configure if the barcode shall be rendered using SVG, a HTML Canvas or an image. Furthermore the component exposes `renderElementRef` on its class.

Both were missing from TypeScript typings.  This patch adds those.