### PR TITLE
Add missing `ITF` format to typescript definition files

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ export interface Options {
     | "CODE128"
     | "EAN13"
     | "ITF14"
+    | "ITF"
     | "MSI"
     | "pharmacode"
     | "codabar"


### PR DESCRIPTION
`js-barcode` actually also allows plain `ITF` codes aside from the more specific `ITF14`. This updates the Typescript-Types for the `format` to resemble that `ITF` can be used as well.

**Changelog:**
- Allow "ITF" format apart from "ITF14" for generic Interleaved 2 of 5 codes