### PR TITLE
Missing React Import

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 export interface Options {
   width?: number;
   height?: number;


### PR DESCRIPTION
Adding React import to def for instances where it isn't global
