### PR TITLE
Add support for CODE128A, CODE128B and CODE128C

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,8 @@ export interface Options {
   format?:
     | "CODE39"
     | "CODE128"
+    | "CODE128B"
+    | "CODE128C"
     | "EAN13"
     | "ITF14"
     | "ITF"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ export interface Options {
   format?:
     | "CODE39"
     | "CODE128"
+    | "CODE128A"
     | "CODE128B"
     | "CODE128C"
     | "EAN13"


### PR DESCRIPTION
Add type support for CODE128A, CODE128B, and CODE128C, allowing users to choose these modes manually instead of automatically switching between them.
https://github.com/lindell/JsBarcode?tab=readme-ov-file#supported-barcodes