### PR TITLE
Supported all formats available in JsBarcode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,13 +7,25 @@ export interface Options {
   format?:
     | "CODE39"
     | "CODE128"
+    | "CODE128A"
+    | "CODE128B"
+    | "CODE128C"
     | "EAN13"
+    | "EAN8"
+    | "EAN5"
+    | "EAN2"
+    | "UPC"
+    | "UPCE"
     | "ITF14"
     | "ITF"
     | "MSI"
+    | "MSI10"
+    | "MSI11"
+    | "MSI1010"
+    | "MSI1110"
     | "pharmacode"
     | "codabar"
-    | "upc";
+    | "GenericBarcode";
   displayValue?: boolean;
   fontOptions?: string;
   font?: string;


### PR DESCRIPTION
The type definitions for react-barcode only cover some of the formats supported by JsBarcode, so I made adjustments to cover all types.
https://github.com/lindell/JsBarcode/blob/v3.11.0/src/barcodes/index.js

This Pull Request fully includes #95.