### PR TITLE
Add support for CODE128 (GS1-128/EAN-128) barcode format

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,7 @@ export interface Options {
   marginBottom?: number;
   marginLeft?: number;
   marginRight?: number;
+  ean128: boolean;
 }
 
 export interface BarcodeProps extends Options {

--- a/src/react-barcode.js
+++ b/src/react-barcode.js
@@ -81,6 +81,7 @@ Barcode.propTypes = {
   marginRight: PropTypes.number,
   id: PropTypes.string,
   className: PropTypes.string,
+  ean128: PropTypes.bool,
 };
 
 Barcode.defaultProps = {
@@ -99,6 +100,7 @@ Barcode.defaultProps = {
   lineColor: '#000000',
   margin: 10,
   className: '',
+  ean128: false,
 };
 
 module.exports = Barcode;


### PR DESCRIPTION
## What

This pull request is a change to make the option `ean128` available for CODE128.

Define `ean128: true` to allow CODE128 to be encoded as GS1-128/EAN-128.
The default value of `ean128` is defined to be `false` and does not affect existing processing.

## Ref

> ### ean128 option for CODE128
>
> Enable encoding CODE128 as GS1-128/EAN-128.
>
> ```js
> JsBarcode("#barcode", "12345678", {
>   format: "CODE128C",
>   ean128: true
> });
> ```
> 
> CODE128 - lindell/JsBarcode Wiki
> https://github.com/lindell/JsBarcode/wiki/CODE128