### PR TITLE
fix(type): change property ean128 to be optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,7 +40,7 @@ export interface Options {
   marginBottom?: number;
   marginLeft?: number;
   marginRight?: number;
-  ean128: boolean;
+  ean128?: boolean;
 }
 
 export interface BarcodeProps extends Options {


### PR DESCRIPTION
Explained on:
https://github.com/kciter/react-barcode/commit/0f82a5647e820cb8f0bbcb200249dffbfcdd62bd#commitcomment-142113801

Basically:
Adding ean128 as an mandatory prop is a breaking change, how about we add an optional prop, using the "?" symbol?

This change will clear errors such as:

```
Type error: No overload matches this call.
  Overload 1 of 2, '(props: BarcodeProps | Readonly<BarcodeProps>): Barcode', gave the following error.
    Property 'ean128' is missing in type '{ value: string; format: "ITF"; displayValue: false; }' but required in type 'Readonly<BarcodeProps>'.
  Overload 2 of 2, '(props: BarcodeProps, context: any): Barcode', gave the following error.
    Property 'ean128' is missing in type '{ value: string; format: "ITF"; displayValue: false; }' but required in type 'Readonly<BarcodeProps>'
```

And since this call already has an [default value](https://github.com/kciter/react-barcode/blob/c3a18d5d5dfeae37ed8bb9bdb43b8bfe2f3fa8e2/src/react-barcode.js#L87), not sending the property will have the same result as before.