### PR TITLE
Add missing "id" and "className" to the component type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,8 @@ export interface Options {
   marginBottom?: number;
   marginLeft?: number;
   marginRight?: number;
+  id?: string;
+  className?: string;
   ean128?: boolean;
 }
 


### PR DESCRIPTION
It seems that the properties `className` and `id` are missing from the component property type definition. They seem to be supported and work with ts-ignore, but without it there will of course be an error.

This change adds type entries for the missing properties and should fix the issue.


