### PR TITLE
Add bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/kciter/react-barcode.git"
   },
+  "bugs": {
+    "url": "https://github.com/kciter/react-barcode/issues"
+  },
   "license": "ISC",
   "files": [
     "lib"


### PR DESCRIPTION
## Summary

- Add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Notes

This is metadata-only. It does not change runtime code, dependencies, build output, exports, or package entry points.

## Verification

```text
npm view react-barcode@1.6.1 name version repository homepage bugs license --json
python3 -m json.tool package.json
metadata assertion passed
git diff --check passed
```
