### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "react-barcode",
   "version": "1.6.1",
+  "bugs": {
+    "url": "https://github.com/kciter/react-barcode/issues"
+  },
   "description": "React component to generate barcodes",
   "keywords": [
     "react",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.